### PR TITLE
adding alignments to kitchen2012 data

### DIFF
--- a/datasets/akse/__init__.py
+++ b/datasets/akse/__init__.py
@@ -6,11 +6,13 @@ from clldutils.misc import slug
 
 from pylexibank.util import xls2csv
 from pylexibank.dataset import CldfDataset, valid_Value as vv_base
+from pylexibank.lingpy_util import clean_string, iter_alignments, getEvoBibAsSource
+import lingpy as lp
 
 
 def download(dataset):
     xls2csv(dataset.raw.joinpath('Semitic.Wordlists.xls'), outdir=dataset.raw)
-
+    xls2csv(dataset.raw.joinpath('Semitic.Codings.Multistate.xlsx'), outdir=dataset.raw)
 
 def valid_Value(row):
     return vv_base(row) and row['Value'] != '---'
@@ -32,8 +34,30 @@ def cldf(dataset, glottolog, concepticon, **kw):
                 header = row
             if i > 0:
                 rows.append(row)
+    cheader, crows = None, []
+    with UnicodeReader(
+            dataset.raw.joinpath('Semitic.Codings.Multistate.Sheet1.csv')) as reader:
+        for i, row in enumerate(reader):
+            row = [c.strip() for c in row]
+            if i == 0:
+                cheader = row
+            if i > 0:
+                crows.append(row)
 
     langs = header[1:]
+    clean_langs = {
+            """Gɛ'ɛz""": "Ge'ez",
+            "Tigrɛ" : "Tigre",
+            'ʷalani' : "Walani",
+            "Ogadɛn Arabic" : "Ogaden Arabic",
+            "Mɛhri" : "Mehri",
+            "Gibbali" : "Jibbali",
+            }
+    correct_concepts = {
+            'Cold (air)' : 'Cold (of air)',
+            }
+    src = getEvoBibAsSource('Kitchen2012')
+
     with CldfDataset((
             'ID',
             'Language_ID',
@@ -41,17 +65,70 @@ def cldf(dataset, glottolog, concepticon, **kw):
             'Parameter_ID',
             'Parameter_name',
             'Value',
+            'Segments'
             ),
             dataset) as ds:
+        D = {0 : ['doculect', 'concept', 'ipa', 'tokens']}
+        idx = 1
+        ds.sources.add(src)
         for row in rows:
             concept = row[0]
             for i, col in enumerate(row[1:]):
                 lang = langs[i]
-                ds.add_row([
-                    '%s-%s' % (slug(lang), slug(concept)),
-                    language_map[lang],
-                    lang,
-                    concepticon[concept],
-                    concept,
-                    col,
-                ])
+                if col != '---':
+                    cleaned_string = clean_string(col, merge_vowels=True,
+                            preparse=[("'", "ˈ"), ('?', "ʔ"), ('//', '/'),
+                            ('', ''), ('7', 's'),
+                            ('', '')])[0]
+                    ds.add_row([
+                        'Kitchen2012-'+str(idx),
+                        language_map[lang],
+                        clean_langs.get(lang, lang),
+                        concepticon[concept],
+                        concept,
+                        col,
+                        cleaned_string 
+                    ])
+                    D[idx] = [clean_langs.get(lang, lang), concept, col, cleaned_string]
+                    idx += 1
+        
+        wl = lp.Wordlist(D)
+        id2cog = {}
+        errors = []
+        for row in crows:
+            taxon = row[0]
+            for i, (concept, cog) in enumerate(zip(cheader[1:], row[1:])):
+                nconcept = rows[i][0]
+                if cog != '-':
+                    idxs = wl.get_dict(taxon=taxon)
+                    if idxs.get(nconcept, ''):
+                        id2cog[idxs[nconcept][0]] = concept + '-' + cog
+                    else:
+                        errors += [(concept, nconcept, taxon)]
+        bad_cogs = 1
+        cognates = []
+        for k in wl:
+            cognates = []
+            if k in id2cog:
+                cogid = id2cog[k]
+            else:
+                cogid = str(bad_cogs)
+                bad_cogs += 1
+                id2cog[k] = cogid
+
+        wl.add_entries('cog', id2cog, lambda x: x)
+        wl.renumber('cog')
+        for k in wl:
+            cognates += [[
+                'Kitchen2012-'+str(k),
+                ds.name,
+                wl[k, 'ipa'],
+                wl[k, 'concept']+'-'+str(wl[k, 'cogid']),
+                '',
+                'expert',
+                'Kitchen2012', 
+                '', '', '']]
+
+        dataset.cognates.extend(iter_alignments(lp.Alignments(wl), cognates))
+
+

--- a/datasets/akse/metadata.json
+++ b/datasets/akse/metadata.json
@@ -5,7 +5,7 @@
             "@language": "en"
         }
     ],
-    "dc:title": "Andrew Kitchen et al.: Semitic languages",
+    "dc:title": "Lexicostatistic Wordlist of Semitic Languages",
     "dc:bibliographicCitation": "Bayesian phylogenetic analysis of Semitic languages identifies an Early Bronze Age origin of Semitic in the Near East. Andrew Kitchen, Christopher Ehret, Shiferaw Assefa, Connie J. Mulligan. Proc. R. Soc. B 2009 -; DOI: 10.1098/rspb.2009.0408. Published 29 April 2009",
     "dc:license": null,
     "dc:related": "http://rspb.royalsocietypublishing.org/content/early/2009/04/27/rspb.2009.0408",

--- a/datasets/cbvl/__init__.py
+++ b/datasets/cbvl/__init__.py
@@ -94,5 +94,3 @@ def cldf(dataset, glottolog, concepticon, **kw):
                     '-'.join([slug(line[0]), str(p2c.get(val, val))]),
                     '', 'expert', SOURCE, '', '', '']]
                 idx += 1
-
-        dataset.write_cognates()

--- a/datasets/cddb/__init__.py
+++ b/datasets/cddb/__init__.py
@@ -146,11 +146,10 @@ def cldf(dataset, glottolog, concepticon, **kw):
             ds.name,
             alms[k, 'ipa'],
             '-'.join([slug(alms[k, 'concept']), str(alms[k, 'cogid'])]),
-                '',
-                'expert',
-                SOURCE,
-                '', '', ''] for k in alms]
+            '',
+            'expert',
+            SOURCE,
+            '', '', ''] for k in alms]
 
         dataset.cognates.extend(iter_alignments(alms, cognates,
             method='library'))
-        dataset.write_cognates()

--- a/datasets/pcbd/__init__.py
+++ b/datasets/pcbd/__init__.py
@@ -22,19 +22,6 @@ def download(dataset, **kw):
 
 
 def cldf(dataset, glottolog, concepticon, **kw):
-    """
-    Implements the conversion of the raw data to CLDF dataset(s).
-
-    :param dataset: provides access to the information in supplementary files as follows:\
-     - the JSON object from `metadata.json` is available as `dataset.md`\
-     - items from languages.csv are available as `dataset.languages`\
-     - items from concepts.csv are available as `dataset.concepts`\
-     - if a Concepticon conceptlist was specified in metadata.json, its ID is available\
-       as `dataset.conceptlist`
-    :param glottolog: a pyglottolog.api.Glottolog` instance.
-    :param concepticon:  a pyconcepticon.api.Concepticon` instance.
-    :param kw: All arguments passed on the command line.
-    """
 
     for dset, srckey in zip(DSETS, SOURCES):
         wl = lp.Wordlist(dataset.dir.joinpath('raw', dset).as_posix())
@@ -91,6 +78,3 @@ def cldf(dataset, glottolog, concepticon, **kw):
 
             dataset.cognates.extend(iter_alignments(wl, cognates,
                 method='progressive', prefix=srckey + '-'))
-
-
-    dataset.write_cognates()


### PR DESCRIPTION
This init-file actually illustrates how the clean_string function from lingpy can be used to roughly clean minor errors and to segment data in larger datsets. The function allows for a pre-parse keyword, to which one can pass tuples of source and target for replacement with string.replace(s, t). In this way, inor errors can be qucily addressed.

Note that the Kitchen2012 data offers cognate sets for words which are noted as being absent (!) in the original spreadsheet. This means essentially, that either they did not want to write the words in the spreadsheet with the words, or that they miscoded virtual cognates for non-existing data. I decided to ignore these cases, as it is only some 50 instances. The alignments seem to be okay, more or less, and the lingpy-accuracy is some 91%, so we do not run in trouble, although we see again many partial cognates.