### PR TITLE
Fixing some relative imports

### DIFF
--- a/datasets/abvd/__init__.py
+++ b/datasets/abvd/__init__.py
@@ -8,7 +8,7 @@ from pylexibank.providers import abvd
 from pylexibank.dataset import Unmapped
 from tqdm import tqdm
 
-from author_notes_map import MAP
+from .author_notes_map import MAP
 
 SECTION = 'austronesian'
 TRANSCRIPTION_REPORT_CFG = dict(column='Segments', segmentized=True)

--- a/datasets/transnewguinea/__init__.py
+++ b/datasets/transnewguinea/__init__.py
@@ -7,7 +7,7 @@ from pycldf.sources import Source
 
 from pylexibank.dataset import CldfDataset, Unmapped
 
-from util import get_all, BASE_URL
+from .util import get_all, BASE_URL
 
 
 def download(dataset):


### PR DESCRIPTION
Otherwise `lexibank download` fails on python 3. I think these should also work on py2 (is anyone using py2?)